### PR TITLE
CVE-2018-4407 PoC docs: Advice to use linux capabilities instead of running with full root privileges

### DIFF
--- a/apple/darwin-xnu/icmp_error_CVE-2018-4407/README.md
+++ b/apple/darwin-xnu/icmp_error_CVE-2018-4407/README.md
@@ -35,3 +35,12 @@ sudo ./crash_all
 ```
 
 Use `crash_all` with care: it will crash any unpatched Apple device that is connected to the same network as you.
+
+Alternatively you can give the `CAP_NET_RAW` capability to the binaries instead of using them under full root privileges:
+
+```bash
+sudo setcap cap_net_raw=ep crash_all
+sudo setcap cap_net_raw=ep direct_attack
+```
+
+Some libs are required to use setcap (libcap-ng-utils, libcap-progs, libcap2)


### PR DESCRIPTION
Added a small advice at the end of README for giving the `CAP_NET_RAW` capability required for opening a raw socket instead of running the binaries with sudo (temporary root privileges).

Once the capability is granted any user can run `direct_attack` or `crash_all` with their privileges.

Let's break up with the root model :)